### PR TITLE
修正在 iOS Safari 出现奇怪的样式的问题

### DIFF
--- a/css/single.css
+++ b/css/single.css
@@ -530,6 +530,8 @@ main img{
 .post-comments{ animation: fade-in-top .3s .5s backwards; -webkit-animation: fade-in-top .3s .5s backwards; }
 
 .post-comments input, .post-comments textarea{
+    -webkit-appearance: none;
+    -moz-appearance: none;
     width: 100%;
     display: block;
 }


### PR DESCRIPTION
## Before

<img width="509" alt="2018-08-13 22 54 38" src="https://user-images.githubusercontent.com/8687182/44039962-d715f088-9f4c-11e8-81c3-fefd37079a2b.png">

## After

<img width="509" alt="2018-08-13 22 57 33" src="https://user-images.githubusercontent.com/8687182/44039988-ed2e2106-9f4c-11e8-9f33-aa3f673f9c81.png">
